### PR TITLE
Adding monitor class

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
   forge_modules:
     augeas: "camptocamp/augeas"
     stdlib: "puppetlabs/stdlib"
+    inifile: "puppetlabs/inifile"
     augeasproviders_core: "herculesteam/augeasproviders_core"
     augeasproviders_postgresql: "herculesteam/augeasproviders_postgresql"
   symlinks:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Classes:
  * pgpool::config
  * pgpool::service
  * pgpool::package
+ * pgpool::monitor
  * pgpool::config::watchdog
  * pgpool::config::pools
  * pgpool::config::loadbalance
@@ -164,3 +165,8 @@ This has only been tested on RedHat/CentOS 6.  It might work on Debian/Ubuntu.
 ## Development
 
 Pull requests welcome.
+
+## Other resources
+
+To use pgpool::monitor, the code for the pgpool-monitor package is available
+from [pgpool-monitor](https://github.com/rackerlabs/pgpool-monitor).

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -1,0 +1,164 @@
+# == Class: pgpol::monitor
+#
+# This is a class to pull in the custom pgpool monitoring for monitoring
+# pgpool instances.  You should specify the connection information for the
+# database and to talk to pgpool via pcp.  The db test will attempt to create
+# and write to a temp table to ensure that write connections work as well as
+# doing a "SELECT 1" to test read connections. The pcp monitoring will return
+# the total number of backends, number available and number of processes.
+#
+# See https://github.com/rackerlabs/pgpool-monitor
+#
+# == Parameters
+#
+# [*ensure*]
+#  This is one of <tt>present</tt>, <tt>latest</tt>, or <tt>absent</tt>.
+#  Defaults to <tt>latest</tt>.
+#
+# [*db_host*]
+#  String. The host to connect to pgpool on for postgresql connectons.
+#  Defaults to <tt>localhost</tt>
+#
+# [*db_port*]
+#  Integer. The port to connect to pgpool on for the postgresql connections.
+#  Defaults to <tt>9999</tt>.
+#
+# [*db_database*]
+#  String. The database to connect to and try to read/write.
+#  Defaults to <tt>postgres</tt>.
+#
+# [*db_user*]
+#  String. The user to connect to pgpool as for postgresql queries.
+#  Defaults to <tt>zabbix</tt>.
+#
+# [*db_password*]
+#  String. The password use to connect to pgpool as for postgresql queries.
+#  Defaults to <tt></tt>.
+#
+# [*pcp_timeout*]
+#  Integer. The timeout used to connect to the pcp port of pgpool.
+#  Defaults to <tt>9898</tt>.
+#
+# [*pcp_host*]
+#  String. The host used to connect to the pcp.
+#  Defaults to <tt>localhost</tt>.
+#
+# [*pcp_port*]
+#  Integer. The port used to connect to pcp.
+#  Defaults to <tt>9898</tt>.
+#
+# [*pcp_user*]
+#  String. The user used to connect to pcp.
+#  Defaults to <tt>zabbix</tt>.
+#
+# [*pcp_password*]
+#  String. The password used to connect to pcp.
+#  Defaults to <tt>zabbix</tt>.
+#
+# === Examples
+#
+# include pgpool::monitor
+#
+# class { 'pgpool::monitor':
+#   ensure => absent
+# }
+#
+# === Authors
+#
+# * Alex Schultz <mailto:alex.schultz@rackspace.com>
+#
+class pgpool::monitor (
+  $ensure           = latest,
+  $db_host          = 'localhost',
+  $db_port          = 9999,
+  $db_database      = 'postgres',
+  $db_user          = 'zabbix',
+  $db_password      = '',
+  $pcp_timeout      = 10,
+  $pcp_host         = 'localhost',
+  $pcp_port         = 9898,
+  $pcp_user         = 'zabbix',
+  $pcp_password     = 'zabbix',
+) {
+
+  if $ensure == absent {
+    $file_ensure = absent
+    $ini_ensure = absent
+  } else {
+    $file_ensure = file
+    $ini_ensure = present
+  }
+
+  package { 'pgpool_monitor':
+    ensure => $ensure,
+  }
+
+  $config_file = '/etc/pgpool_monitor.cfg'
+  file { $config_file:
+    ensure  => $file_ensure,
+    owner   => 'zabbix',
+    group   => 'zabbix',
+    require => Package['pgpool_monitor'],
+  }
+
+  $config_defaults = {
+    'ensure' => $ini_ensure,
+    'path'   => $config_file
+  }
+
+  $config_settings = {
+    'db_host' => {
+      section => 'db',
+      setting => 'host',
+      value   => $db_host
+    },
+    'db_port' => {
+      section => 'db',
+      setting => 'port',
+      value   => $db_port
+    },
+    'db_database' => {
+      section => 'db',
+      setting => 'database',
+      value   => $db_database
+    },
+    'db_user' => {
+      section => 'db',
+      setting => 'user',
+      value   => $db_user
+    },
+    'db_password' => {
+      section => 'db',
+      setting => 'password',
+      value   => $db_password
+    },
+    'pcp_timeout' => {
+      section => 'pcp',
+      setting => 'timeout',
+      value   => $pcp_timeout
+    },
+    'pcp_host' => {
+      section => 'pcp',
+      setting => 'host',
+      value   => $pcp_host
+    },
+    'pcp_port' => {
+      section => 'pcp',
+      setting => 'port',
+      value   => $pcp_port
+    },
+    'pcp_user' => {
+      section => 'pcp',
+      setting => 'user',
+      value   => $pcp_user
+    },
+    'pcp_password' => {
+      section => 'pcp',
+      setting => 'password',
+      value   => $pcp_password
+    },
+  }
+  if $file_ensure == file {
+    create_resources(ini_setting, $config_settings, $config_defaults)
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mwhahaha-pgpool",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "mwhahaha",
   "summary": "A puppet module to configure pgpool",
   "license": "Apache 2.0",

--- a/spec/classes/monitor_spec.rb
+++ b/spec/classes/monitor_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+describe 'pgpool::monitor' do
+  context 'on RedHat' do
+    let :facts do
+    {
+    }
+    end
+
+    context 'with defaults for all parameters' do
+      it {
+        should contain_class('pgpool::monitor')
+        should contain_package('pgpool_monitor').with_ensure('latest')
+        should contain_file('/etc/pgpool_monitor.cfg').with(
+          'ensure' => 'file',
+          'owner'  => 'zabbix',
+          'group'  => 'zabbix')
+        should contain_ini_setting('db_host').with(
+          'ensure'  => 'present',
+          'section' => 'db',
+          'setting' => 'host',
+          'value'   => 'localhost')
+        should contain_ini_setting('db_port').with(
+          'ensure'  => 'present',
+          'section' => 'db',
+          'setting' => 'port',
+          'value'   => '9999')
+        should contain_ini_setting('db_database').with(
+          'ensure'  => 'present',
+          'section' => 'db',
+          'setting' => 'database',
+          'value'   => 'postgres')
+        should contain_ini_setting('db_user').with(
+          'ensure'  => 'present',
+          'section' => 'db',
+          'setting' => 'user',
+          'value'   => 'zabbix')
+        should contain_ini_setting('db_password').with(
+          'ensure'  => 'present',
+          'section' => 'db',
+          'setting' => 'password',
+          'value'   => '')
+        should contain_ini_setting('pcp_timeout').with(
+          'ensure'  => 'present',
+          'section' => 'pcp',
+          'setting' => 'timeout',
+          'value'   => '10')
+        should contain_ini_setting('pcp_host').with(
+          'ensure'  => 'present',
+          'section' => 'pcp',
+          'setting' => 'host',
+          'value'   => 'localhost')
+        should contain_ini_setting('pcp_port').with(
+          'ensure'  => 'present',
+          'section' => 'pcp',
+          'setting' => 'port',
+          'value'   => '9898')
+        should contain_ini_setting('pcp_user').with(
+          'ensure'  => 'present',
+          'section' => 'pcp',
+          'setting' => 'user',
+          'value'   => 'zabbix')
+        should contain_ini_setting('pcp_password').with(
+          'ensure'  => 'present',
+          'section' => 'pcp',
+          'setting' => 'password',
+          'value'   => 'zabbix')
+      }
+    end
+
+    context 'with ensure set to absent' do
+      let(:params) { {
+          :ensure => 'absent'
+      } }
+      it {
+        should contain_class('pgpool::monitor')
+        should contain_package('pgpool_monitor').with_ensure('absent')
+        should contain_file('/etc/pgpool_monitor.cfg').with(
+          'ensure' => 'absent',
+          'owner'  => 'zabbix',
+          'group'  => 'zabbix')
+        should_not contain_ini_setting('db_host').with(
+          'ensure'  => 'absent',
+          'section' => 'db',
+          'setting' => 'host',
+          'value'   => 'localhost')
+      }
+    end
+  end
+end


### PR DESCRIPTION
Adding in support for monitoring using https://github.com/rackerlabs/pgpool-monitor to monitor basic pgpool functions. The pgpool-monitor class can be used in conjunction with things like Zabbix to collect the basic health information from pgpool.
