### PR TITLE
Don't hardcode pgpool paths when reloading

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -42,15 +42,9 @@ class pgpool::service {
     enable => $::pgpool::service_enable_real
   }
 
-  $exec_command_reload = $::osfamily ? {
-    /RedHat/ => '/usr/bin/pgpool reload',
-    /Debian/ => '/usr/sbin/pgpool reload',
-    default  => '/usr/bin/pgpool reload',
-  }
-
-
   exec { 'pgpool_reload':
-    command     => $exec_command_reload,
+    path        => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin',
+    command     => 'pgpool reload',
     require     => Service['pgpool'],
     refreshonly => true,
   }


### PR DESCRIPTION
Instead set the `path` parameter for the `Exec['pgpool_reload']`
resource so that the pgpool binary can be found correctly on different
operating systems whose packages install pgpool in different paths.
