### PR TITLE
Support param auth_method in resource pgpool::hba

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ pgpool::pool_passwd { 'my_app_user':
 
 # configure the pgpool hba configuration
 pgpool::hba { 'my_app_user':
-  type     => 'host',
-  database => 'my_db_name',
-  user     => 'my_app_user',
-  address  => '127.0.0.1/32',
-  method   => 'md5',
+  type        => 'host',
+  database    => 'my_db_name',
+  user        => 'my_app_user',
+  address     => '127.0.0.1/32',
+  auth_method => 'md5',
 }
 ```
 


### PR DESCRIPTION
Introduce the pgpool::hba::auth_method parameter which can (and should)
be used instead of the slightly misnamed pgpool::hba::method parameter.
The user can use either auth_method or method, but setting both will
result in catalog compilation failure.

The reason behind this is to make the pgpool::hba resource more
consistent with PostgreSQL's documentation of the pg_hba.conf file
(which uses "auth-method" throughout) and more compatible with
puppetlabs/puppetlabs-postgresql's pg_hba.conf implementation in
pg_hba_rule.
