### PR TITLE
Avoid a file_line resource name conflict

### DIFF
--- a/manifests/pcp.pp
+++ b/manifests/pcp.pp
@@ -49,7 +49,7 @@ define pgpool::pcp (
     default => $ensure,
   }
 
-  file_line { $name:
+  file_line { "${name}-pcp.conf":
     ensure => $ensure_real,
     path   => $target_real,
     line   => "${name}:${password_hash}",

--- a/manifests/pool_passwd.pp
+++ b/manifests/pool_passwd.pp
@@ -52,7 +52,7 @@ define pgpool::pool_passwd (
     default => $ensure,
   }
 
-  file_line { $name:
+  file_line { "${name}-pool_passwd":
     ensure => $ensure_real,
     path   => $target_real,
     line   => "${name}:${password_hash}",


### PR DESCRIPTION
Under the hood, pgpool::pcp and pgpool::pool_passwd resrouces create file_line
resources named the same as the pcp/pool_passwd resource that spawned them.
This means if a pcp and pool_passwd resource gets created with the same
username, it leads to a conflict trying to define the same named file_line
resource, even though they're writing to different files.

This gives the file_line resources unique names based on the file they're
writing to