### PR TITLE
config::backend: Add application_name parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,18 @@ class { 'pgpool::config::watchdog': }
 
 # configure our backend systems
 pgpool::config::backend { 'db-n01':
-  id             => '0',
-  hostname       => '10.0.0.4',
-  port           => 5432,
-  data_directory => '/var/lib/pgsql/9.3/data',
+  id               => '0',
+  hostname         => '10.0.0.4',
+  port             => 5432,
+  application_name => 'db-n01',
+  data_directory   => '/var/lib/pgsql/9.3/data',
 }
 pgpool::config::backend { 'db-n02':
-  id             => '1',
-  hostname       => '10.0.0.5',
-  port           => 5432,
-  data_directory => '/var/lib/pgsql/9.3/data',
+  id               => '1',
+  hostname         => '10.0.0.5',
+  port             => 5432,
+  application_name => 'db-n02',
+  data_directory   => '/var/lib/pgsql/9.3/data',
 }
 
 # configure our application user password access

--- a/manifests/config/backend.pp
+++ b/manifests/config/backend.pp
@@ -23,6 +23,10 @@
 #   Integer. This is the port to connect to for the backend.
 #   Defaults to <tt>5432</tt>.
 #
+# [*application_name*]
+#   String. This must match the application_name defined via recovery.conf.
+#   Defaults to <tt>localhost</tt>.
+#
 # [*weight*]
 #   Integer. This is the weight to be configured for this backend.
 #   Defaults to <tt>1</tt>.
@@ -51,21 +55,23 @@
 # Alex Schultz <aschultz@next-development.com>
 #
 define pgpool::config::backend (
-  $ensure         = present,
-  $id             = 0,
-  $hostname       = 'localhost',
-  $port           = 5432,
-  $weight         = 1,
-  $data_directory = '/var/lib/pgsql/9.3/data',
-  $flag           = 'ALLOW_TO_FAILOVER',
+  $ensure           = present,
+  $id               = 0,
+  $hostname         = 'localhost',
+  $port             = 5432,
+  $application_name = 'localhost',
+  $weight           = 1,
+  $data_directory   = '/var/lib/pgsql/9.3/data',
+  $flag             = 'ALLOW_TO_FAILOVER',
 ) {
 
   $backend_config = {
-    "backend_hostname${id}"        => { value => $hostname },
-    "backend_port${id}"            => { value => $port },
-    "backend_weight${id}"          => { value => $weight },
-    "backend_data_directory${id}"  => { value => $data_directory },
-    "backend_flag${id}"            => { value => $flag },
+    "backend_hostname${id}"         => { value => $hostname },
+    "backend_port${id}"             => { value => $port },
+    "backend_application_name${id}" => { value => $application_name },
+    "backend_weight${id}"           => { value => $weight },
+    "backend_data_directory${id}"   => { value => $data_directory },
+    "backend_flag${id}"             => { value => $flag },
   }
 
   $backend_defaults = {


### PR DESCRIPTION
This is required for correct replication_state
and replication_sync_state querying by PGPool
and must match what is set via the primary_conninfo
in reconvery.conf.