### PR TITLE
Update to 0.2.0

### DIFF
--- a/.gemfiles/Gemfile.rspec
+++ b/.gemfiles/Gemfile.rspec
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-puppetversion = ENV['PUPPET_VERSION']
-gem 'puppet', puppetversion, :require => false
-gem 'rspec-core', '3.1.7'
-gem 'puppet-lint'
-gem 'rspec-puppet'
-gem 'rspec-puppet-utils'
-gem 'puppetlabs_spec_helper'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg
 spec/fixtures/modules
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
+  - 2.5.3
+  - 2.5.7
 
-before_install: rm .gemfiles/Gemfile.rspec.lock || true
-gemfile: .gemfiles/Gemfile.rspec
+before_install: rm Gemfile.lock || true
+gemfile: Gemfile
 
 script:
  - "bundle exec rake lint"
@@ -14,31 +12,9 @@ script:
  - "bundle exec rake spec SPEC_OPTS='--format documentation'"
 
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0"
-  - PUPPET_VERSION="~> 3.6.0"
-  - PUPPET_VERSION="~> 3.7.0"
-matrix:
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.1.0"
-    - rvm: 2.1.1
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.1.1
-      env: PUPPET_VERSION="~> 3.0.0"
-    - rvm: 2.1.1
-      env: PUPPET_VERSION="~> 3.1.0"
-    - rvm: 2.1.1
-      env: PUPPET_VERSION="~> 3.2.0"
-    - rvm: 2.1.1
-      env: PUPPET_VERSION="~> 3.3.0"
-    - rvm: 2.1.1
-      env: PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 5.5.0"
+  - PUPPET_VERSION="~> 6.17.0"
+#matrix:
+#  exclude:
+#    - rvm: 2.5.3
+#      env: PUPPET_VERSION="~> 6.17.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,22 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+gem 'metadata-json-lint'
+gem 'puppetlabs_spec_helper'
+gem 'rake'
+gem 'rspec-puppet'
+gem 'rspec-puppet-facts'
+gem 'rspec-puppet-utils'
+
+# vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
+# TODO(mwhahaha): remove this after deprecation period
+PuppetLint.configuration.send('disable_variable_is_lowercase')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Validate manifests, templates, and ruby files"

--- a/manifests/config/watchdog.pp
+++ b/manifests/config/watchdog.pp
@@ -30,7 +30,7 @@
 #   String. The auth key to use for the watchdog.
 #   Defaults to <tt></tt>.
 #
-# [*delegate_IP*]
+# [*delegate_ip*]
 #   String. The virtual IP for pgpool.
 #   Defaults to <tt></tt>.
 #
@@ -125,6 +125,12 @@
 #   String. The directory where the UNIX domain socket accepting pgpool-II watchdog IPC connections will be created.
 #   Defaults to <tt>/tmp</tt>.
 #
+# === DEPECATED
+#
+# [*delegate_IP*]
+#   String. The virtual IP for pgpool.
+#   Defaults to <tt></tt>.
+#
 # === Variables
 #
 # N/A
@@ -144,7 +150,7 @@ class pgpool::config::watchdog (
   $wd_hostname                   = '',
   $wd_port                       = 9000,
   $wd_authkey                    = '',
-  $delegate_IP                   = '',
+  $delegate_ip                   = '',
   $ifconfig_path                 = '/sbin',
   $if_up_cmd                     = 'ifconfig eth0:0 inet $_IP_$ netmask 255.255.255.0',
   $if_down_cmd                   = 'ifconfig eth0:0 down',
@@ -167,8 +173,13 @@ class pgpool::config::watchdog (
   $wd_monitoring_interfaces_list = '',
   $wd_priority                   = 1,
   $wd_ipc_socket_dir             = '/tmp',
+  # deprecated
+  $delegate_IP                   = undef,
 ) {
 
+  if $delegate_IP {
+    warning('DEPRECATED: $delegate_IP has been replaced by $delegate_ip and will be removed in a future version')
+  }
   $watchdog_config = {
     'use_watchdog'                  => { value => $use_watchdog },
     'trusted_servers'               => { value => $trusted_servers },
@@ -176,7 +187,7 @@ class pgpool::config::watchdog (
     'wd_hostname'                   => { value => $wd_hostname },
     'wd_port'                       => { value => $wd_port },
     'wd_authkey'                    => { value => $wd_authkey },
-    'delegate_IP'                   => { value => $delegate_IP },
+    'delegate_IP'                   => { value => pick($delegate_IP, $delegate_ip) },
     'ifconfig_path'                 => { value => $ifconfig_path },
     'if_up_cmd'                     => { value => $if_up_cmd },
     'if_down_cmd'                   => { value => $if_down_cmd },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,15 +150,15 @@ class pgpool (
   class { 'pgpool::config': }
 
   if ($ensure == absent) {
-    Anchor['pgpool::begin'] ->
-      Class['pgpool::service'] ->
-      Class['pgpool::config'] ->
-      Class['pgpool::package']
+    Anchor['pgpool::begin']
+      -> Class['pgpool::service']
+        -> Class['pgpool::config']
+          -> Class['pgpool::package']
   } else {
-    Anchor['pgpool::begin'] ->
-      Class['pgpool::package'] ->
-      Class['pgpool::config'] ->
-      Class['pgpool::service']
+    Anchor['pgpool::begin']
+      -> Class['pgpool::package']
+        -> Class['pgpool::config']
+          -> Class['pgpool::service']
 
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mwhahaha-pgpool",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "author": "mwhahaha",
   "summary": "A puppet module to configure pgpool",
   "license": "Apache-2.0",
@@ -10,7 +10,7 @@
   "tags": [ "pgpool", "database", "postgresql" ],
   "dependencies": [
     {
-      "version_range": ">= 1.0.0 < 5.0.0",
+      "version_range": ">= 1.0.0 < 6.5.0",
       "name": "puppetlabs-stdlib"
     },
     {
@@ -35,35 +35,33 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
-        "6"
+        "6",
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "5",
-        "6"
+        "6",
+        "7",
+        "8"
       ]
     },
     {
-      "operatingsystem": "OracleLinux",
+      "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "5",
-        "6"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "5",
-        "6"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=2.7.0 <4.0.0"
+      "version_requirement": ">=2.7.0 <7.0.0"
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,90 +1,101 @@
 require 'spec_helper'
+
 describe 'pgpool' do
 
- shared_examples 'a Linux OS with defaults' do
-    it {
-      should contain_class('pgpool')
-      should contain_class('pgpool::package')
-      should contain_package('pgpool').
-        with_name("#{pkg_name}").
-        with_ensure('present')
-      should contain_class('pgpool::config')
-      should contain_file("#{config_path}/pgpool.conf").
-        with_ensure('file').
-        with_owner('postgres').
-        with_group('postgres')
-      should contain_file("#{defaults_path}/#{pkg_name}").
-        with_ensure('file').
-        with_owner('postgres').
-        with_group('postgres')
-      should contain_class('pgpool::service')
-      should contain_service('pgpool').
-        with_ensure('running')
-      should contain_exec('pgpool_reload')
-    }
-  end
-
-  context 'on RedHat' do
-    let (:facts) { {
-      :kernel          => 'Linux',
-      :osfamily        => 'RedHat',
-      :operatingsystem => 'CentoOS',
-      :concat_basedir  => '/tmp'
-    } }
-    let(:config_path) { '/etc/pgpool-II-93' }
-    let(:defaults_path) { '/etc/sysconfig' }
-    let(:pkg_name) { 'pgpool-II-93' }
-    it_behaves_like 'a Linux OS with defaults' do
+   shared_examples_for 'a Linux OS' do
+     context 'with defaults' do
+       it {
+         should contain_class('pgpool')
+         should contain_class('pgpool::package')
+         should contain_package('pgpool').
+           with_name("#{platform_params[:pkg_name]}").
+           with_ensure('present')
+         should contain_class('pgpool::config')
+         should contain_file("#{platform_params[:config_path]}/pgpool.conf").
+           with_ensure('file').
+           with_owner('postgres').
+           with_group('postgres')
+         should contain_file("#{platform_params[:defaults_path]}/#{platform_params[:pkg_name]}").
+           with_ensure('file').
+           with_owner('postgres').
+           with_group('postgres')
+         should contain_class('pgpool::service')
+         should contain_service('pgpool').
+           with_ensure('running')
+         should contain_exec('pgpool_reload')
+       }
     end
   end
 
-  context 'on Debian' do
-    let (:facts) { {
-      :kernel          => 'Linux',
-      :osfamily        => 'Debian',
-      :operatingsystem => 'Debian',
-      :concat_basedir  => '/tmp'
-    } }
-    let(:config_path) { '/etc/pgpool2' }
-    let(:defaults_path) { '/etc/default' }
-    let(:pkg_name) { 'pgpool2' }
-    it_behaves_like 'a Linux OS with defaults' do
+
+  shared_examples_for 'a RedHat OS' do
+    context 'with package and paths' do
+      let(:defaults_path) { '/etc/sysconfig' }
+      let(:params) { {
+        :config_dir   => '/etc/pgpool-II',
+        :package_name => 'pgpool-II-pg93',
+        :service_name => 'pgpool'
+      } }
+      it {
+        should contain_class('pgpool')
+        should contain_class('pgpool::package')
+        should contain_package('pgpool').
+          with_name(params[:package_name]).
+          with_ensure('present')
+        should contain_class('pgpool::config')
+        should contain_file("#{params[:config_dir]}/pgpool.conf").
+          with_ensure('file').
+          with_owner('postgres').
+          with_group('postgres')
+        should contain_file("#{defaults_path}/#{params[:service_name]}").
+          with_ensure('file').
+          with_owner('postgres').
+          with_group('postgres')
+        should contain_class('pgpool::service')
+        should contain_service('pgpool').
+          with_ensure('running')
+        should contain_exec('pgpool_reload')
+      }
     end
   end
 
-  context 'on RedHat with Custom package and paths' do
-    let (:facts) { {
-      :kernel          => 'Linux',
-      :osfamily        => 'RedHat',
-      :operatingsystem => 'CentoOS',
-      :concat_basedir  => '/tmp'
-    } }
-    let(:defaults_path) { '/etc/sysconfig' }
-    let(:params) { {
-      :config_dir   => '/etc/pgpool-II',
-      :package_name => 'pgpool-II-pg93',
-      :service_name => 'pgpool'
-    } }
-    it {
-      should contain_class('pgpool')
-      should contain_class('pgpool::package')
-      should contain_package('pgpool').
-        with_name(params[:package_name]).
-        with_ensure('present')
-      should contain_class('pgpool::config')
-      should contain_file("#{params[:config_dir]}/pgpool.conf").
-        with_ensure('file').
-        with_owner('postgres').
-        with_group('postgres')
-      should contain_file("#{defaults_path}/#{params[:service_name]}").
-        with_ensure('file').
-        with_owner('postgres').
-        with_group('postgres')
-      should contain_class('pgpool::service')
-      should contain_service('pgpool').
-        with_ensure('running')
-      should contain_exec('pgpool_reload')
-    }
+  shared_examples_for 'a Debian OS' do
+  end
 
+  on_supported_os({
+    :supported_os => [
+      { 'operatingsystem'        => 'CentOS',
+        'operatingsystemrelease' => [ '5', '6', '7', '8' ] },
+      { 'operatingsystem'        => 'Ubuntu',
+        'operatingsystemrelease' => [ '16.04', '18.04', '20.04' ] }
+    ]
+  }).each do |os,facts|
+    context "on #{os}" do
+      let (:facts) {
+        facts.merge!({
+        :concat_basedir  => '/tmp'
+        })
+      }
+
+      let(:platform_params) do
+        case facts[:osfamily]
+        when 'RedHat'
+          {
+            :config_path   => '/etc/pgpool-II-93',
+            :defaults_path => '/etc/sysconfig',
+            :pkg_name      => 'pgpool-II-93'
+          }
+        when 'Debian'
+          {
+            :config_path   => '/etc/pgpool2',
+            :defaults_path => '/etc/default',
+            :pkg_name      => 'pgpool2'
+          }
+        end
+      end
+
+      it_behaves_like 'a Linux OS'
+      it_behaves_like "a #{facts[:osfamily]} OS"
+    end
   end
 end

--- a/spec/classes/monitor_spec.rb
+++ b/spec/classes/monitor_spec.rb
@@ -1,89 +1,82 @@
 require 'spec_helper'
 describe 'pgpool::monitor' do
-  context 'on RedHat' do
-    let :facts do
-    {
+  context 'with defaults for all parameters' do
+    it {
+      should contain_class('pgpool::monitor')
+      should contain_package('pgpool_monitor').with_ensure('latest')
+      should contain_file('/etc/pgpool_monitor.cfg').with(
+        'ensure' => 'file',
+        'owner'  => 'zabbix',
+        'group'  => 'zabbix')
+      should contain_ini_setting('db_host').with(
+        'ensure'  => 'present',
+        'section' => 'db',
+        'setting' => 'host',
+        'value'   => 'localhost')
+      should contain_ini_setting('db_port').with(
+        'ensure'  => 'present',
+        'section' => 'db',
+        'setting' => 'port',
+        'value'   => '9999')
+      should contain_ini_setting('db_database').with(
+        'ensure'  => 'present',
+        'section' => 'db',
+        'setting' => 'database',
+        'value'   => 'postgres')
+      should contain_ini_setting('db_user').with(
+        'ensure'  => 'present',
+        'section' => 'db',
+        'setting' => 'user',
+        'value'   => 'zabbix')
+      should contain_ini_setting('db_password').with(
+        'ensure'  => 'present',
+        'section' => 'db',
+        'setting' => 'password',
+        'value'   => '')
+      should contain_ini_setting('pcp_timeout').with(
+        'ensure'  => 'present',
+        'section' => 'pcp',
+        'setting' => 'timeout',
+        'value'   => '10')
+      should contain_ini_setting('pcp_host').with(
+        'ensure'  => 'present',
+        'section' => 'pcp',
+        'setting' => 'host',
+        'value'   => 'localhost')
+      should contain_ini_setting('pcp_port').with(
+        'ensure'  => 'present',
+        'section' => 'pcp',
+        'setting' => 'port',
+        'value'   => '9898')
+      should contain_ini_setting('pcp_user').with(
+        'ensure'  => 'present',
+        'section' => 'pcp',
+        'setting' => 'user',
+        'value'   => 'zabbix')
+      should contain_ini_setting('pcp_password').with(
+        'ensure'  => 'present',
+        'section' => 'pcp',
+        'setting' => 'password',
+        'value'   => 'zabbix')
     }
-    end
+  end
 
-    context 'with defaults for all parameters' do
-      it {
-        should contain_class('pgpool::monitor')
-        should contain_package('pgpool_monitor').with_ensure('latest')
-        should contain_file('/etc/pgpool_monitor.cfg').with(
-          'ensure' => 'file',
-          'owner'  => 'zabbix',
-          'group'  => 'zabbix')
-        should contain_ini_setting('db_host').with(
-          'ensure'  => 'present',
-          'section' => 'db',
-          'setting' => 'host',
-          'value'   => 'localhost')
-        should contain_ini_setting('db_port').with(
-          'ensure'  => 'present',
-          'section' => 'db',
-          'setting' => 'port',
-          'value'   => '9999')
-        should contain_ini_setting('db_database').with(
-          'ensure'  => 'present',
-          'section' => 'db',
-          'setting' => 'database',
-          'value'   => 'postgres')
-        should contain_ini_setting('db_user').with(
-          'ensure'  => 'present',
-          'section' => 'db',
-          'setting' => 'user',
-          'value'   => 'zabbix')
-        should contain_ini_setting('db_password').with(
-          'ensure'  => 'present',
-          'section' => 'db',
-          'setting' => 'password',
-          'value'   => '')
-        should contain_ini_setting('pcp_timeout').with(
-          'ensure'  => 'present',
-          'section' => 'pcp',
-          'setting' => 'timeout',
-          'value'   => '10')
-        should contain_ini_setting('pcp_host').with(
-          'ensure'  => 'present',
-          'section' => 'pcp',
-          'setting' => 'host',
-          'value'   => 'localhost')
-        should contain_ini_setting('pcp_port').with(
-          'ensure'  => 'present',
-          'section' => 'pcp',
-          'setting' => 'port',
-          'value'   => '9898')
-        should contain_ini_setting('pcp_user').with(
-          'ensure'  => 'present',
-          'section' => 'pcp',
-          'setting' => 'user',
-          'value'   => 'zabbix')
-        should contain_ini_setting('pcp_password').with(
-          'ensure'  => 'present',
-          'section' => 'pcp',
-          'setting' => 'password',
-          'value'   => 'zabbix')
-      }
-    end
-
-    context 'with ensure set to absent' do
-      let(:params) { {
-          :ensure => 'absent'
-      } }
-      it {
-        should contain_class('pgpool::monitor')
-        should contain_package('pgpool_monitor').with_ensure('absent')
-        should contain_file('/etc/pgpool_monitor.cfg').with(
-          'ensure' => 'absent',
-          'owner'  => 'zabbix',
-          'group'  => 'zabbix')
-        should_not contain_ini_setting('db_host').with(
-          'ensure'  => 'absent',
-          'section' => 'db',
-          'setting' => 'host',
-          'value'   => 'localhost')
-      }
-    end
+  context 'with ensure set to absent' do
+    let(:params) { {
+        :ensure => 'absent'
+    } }
+    it {
+      should contain_class('pgpool::monitor')
+      should contain_package('pgpool_monitor').with_ensure('absent')
+      should contain_file('/etc/pgpool_monitor.cfg').with(
+        'ensure' => 'absent',
+        'owner'  => 'zabbix',
+        'group'  => 'zabbix')
+      should_not contain_ini_setting('db_host').with(
+        'ensure'  => 'absent',
+        'section' => 'db',
+        'setting' => 'host',
+        'value'   => 'localhost')
+    }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
 require 'rubygems'
 require 'rspec-puppet-utils'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
+


### PR DESCRIPTION
Changes:
  * Update the tests to use puppet-rspec-facts.
  * Moved Gemfile from .gemfiles to the root
  * Updated travis testing matrix
  * Update metadata to use newer versions of RedHat and Ubuntu
  * Fixes for linting

Deprecations
  * pgpool::config::watchdog::delegate_IP is deprecated. use
    pgpool::config::watchdog::delegate_ip instead.